### PR TITLE
chore: install linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   lint:
     environment: test
     runs-on: ubuntu-latest
-    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: Linter on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       # Specify the OTP and Elixir versions to use when building
       # and running the workflow steps.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,32 @@ jobs:
 
       - name: Run tests
         run: mix test
+
+  lint:
+    environment: test
+    runs-on: ubuntu-latest
+    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    strategy:
+      # Specify the OTP and Elixir versions to use when building
+      # and running the workflow steps.
+      matrix:
+        # You can check the versions you have locally installed by running
+        # erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell
+        otp: ['26']       # Define the OTP version [required]
+        # elixir -v
+        elixir: ['1.15.7']    # Define the elixir version [required]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run linter
+        run: mix credo --strict

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ elixir_wordle-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+/.elixir_ls

--- a/lib/elixir_wordle.ex
+++ b/lib/elixir_wordle.ex
@@ -19,13 +19,12 @@ defmodule ElixirWordle do
       [yes: "y", no: "n"]
     )
 
-    with :yes <- start_game? do
-      Prompt.display(
+    case start_game? do
+      :yes -> Prompt.display(
         """
           Time to play!
         """
       )
-    else
       _ -> Prompt.display("See you next time!")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule ElixirWordle.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      { :prompt, "~> 0.8.1" }
+      {:prompt, "~> 0.8.1"},
+      {:credo, "~> 1.7.1", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,8 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
+  "credo": {:hex, :credo, "1.7.1", "6e26bbcc9e22eefbff7e43188e69924e78818e2fe6282487d0703652bc20fd62", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "e9871c6095a4c0381c89b6aa98bc6260a8ba6addccf7f6a53da8849c748a58a2"},
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+  "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
   "nimble_options": {:hex, :nimble_options, "0.3.7", "1e52dd7673d36138b1a5dede183b5d86dff175dc46d104a8e98e396b85b04670", [:mix], [], "hexpm", "2086907e6665c6b6579be54ef5001928df5231f355f71ed258f80a55e9f63633"},
   "prompt": {:hex, :prompt, "0.8.1", "36476b699fb19a237fadb873fb992d72eb1a421613ffae94683f4222acf5a873", [:mix], [{:nimble_options, "~> 0.3.0", [hex: :nimble_options, repo: "hexpm", optional: false]}], "hexpm", "eb2c12685598fe646cdc832f819f15716f7226f27c41225109bcce3cf50503fe"},
 }


### PR DESCRIPTION
Installs `Credo` linter for `Elixir`, fixes linter problems and updates CI pipeline to run the linter in PRs.